### PR TITLE
Revision data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An ember-cli-deploy plugin to upload index.html files to a REST API. This is use
 Your REST API should follow the spec below. Note that the base URL is configurable; for these examples we assume it's `https://yourapp.com/ember-revisions`.
 
 - Authenticate with basic auth (please use HTTPS!)
-- `GET /ember-revisions`: returns a JSON array of objects for the stored revisions. Fields are `id` (revision key), `created_at` (upload timestamp), and `current` (boolean)
+- `GET /ember-revisions`: returns a JSON array of objects for the stored revisions. Fields are `id` (revision key), `created_at` (upload timestamp), `revision_data` (usually contains revision metadata) and `current` (boolean)
 - `POST /ember-revisions`: expects a JSON body with fields `id` (revision key) and `body` (the index.html contents)
 - `PUT /ember-revisions/<id>`: activates the revision with key `id`
 

--- a/index.js
+++ b/index.js
@@ -49,16 +49,17 @@ module.exports = {
       requiredConfig: ['baseUrl', 'username', 'password'],
 
       upload: function(context) {
-        var restClient  = this.readConfig('restClient');
-        var revisionKey = this.readConfig('revisionKey');
-        var distDir     = this.readConfig('distDir');
-        var filePattern = this.readConfig('filePattern');
-        var keyPrefix   = this.readConfig('keyPrefix');
-        var filePath    = path.join(distDir, filePattern);
+        var restClient   = this.readConfig('restClient');
+        var revisionKey  = this.readConfig('revisionKey');
+        var distDir      = this.readConfig('distDir');
+        var filePattern  = this.readConfig('filePattern');
+        var keyPrefix    = this.readConfig('keyPrefix');
+        var revisionData = this.readConfig('revisionData');
+        var filePath     = path.join(distDir, filePattern);
 
         this.log('Uploading `' + filePath + '`', { verbose: true });
         return this._readFileContents(filePath)
-          .then(restClient.upload.bind(restClient, keyPrefix, revisionKey))
+          .then(restClient.upload.bind(restClient, keyPrefix, revisionKey, revisionData))
           .then(this._uploadSuccessMessage.bind(this))
           .then(function(key) {
             return { key: key };

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -19,12 +19,16 @@ module.exports = CoreObject.extend({
     });
   },
 
-  upload: function(keyPrefix, revisionKey, value) {
+  upload: function(keyPrefix, revisionKey, revisionData, value) {
     var uploadKey = keyPrefix + ':' + revisionKey;
     var requestBody = {
       id: uploadKey,
       body: value
     };
+
+    if(revisionData) {
+      requestBody.revision_data = JSON.stringify(revisionData);
+    }
 
     return denodeify(this._request.post)({ body: requestBody })
       .then(function() {
@@ -66,6 +70,7 @@ module.exports = CoreObject.extend({
         return response.body.map(function(revision) {
           return {
             revision: revision.id,
+            revision_data: JSON.parse(revision.revision_data || '{}'),
             timestamp: new Date(revision.created_at),
             active: revision.current
           };

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -27,7 +27,7 @@ module.exports = CoreObject.extend({
     };
 
     if(revisionData) {
-      requestBody.revision_data = JSON.stringify(revisionData);
+      requestBody.revision_data = revisionData;
     }
 
     return denodeify(this._request.post)({ body: requestBody })
@@ -70,7 +70,7 @@ module.exports = CoreObject.extend({
         return response.body.map(function(revision) {
           return {
             revision: revision.id,
-            revisionData: revision.revision_data ? JSON.parse(revision.revision_data) : null,
+            revisionData: revision.revision_data,
             timestamp: new Date(revision.created_at),
             active: revision.current
           };

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -70,7 +70,7 @@ module.exports = CoreObject.extend({
         return response.body.map(function(revision) {
           return {
             revision: revision.id,
-            revision_data: JSON.parse(revision.revision_data || '{}'),
+            revisionData: revision.revision_data ? JSON.parse(revision.revision_data) : null,
             timestamp: new Date(revision.created_at),
             active: revision.current
           };


### PR DESCRIPTION
This adds revision-data (most likely populated from `ember-cli-deploy-revision-data`) to the API request, and deserializes it, if present. It should make it work seamlessly with `ember-cli-deploy-list-revisions` latest version.

One thing to know about is that unless _all_ deploys have revision data, `ember-cli-deploy-list-revisions` will use the legacy format. After we adopted this I ended up manually going in to clean up old deploys lacking revision data.

![image](https://cloud.githubusercontent.com/assets/3705/17630333/da900be6-608c-11e6-80d7-57cf3d3e0533.png)
