### PR TITLE
Use queryString parameters instead of http basic auth.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
         }
       },
 
-      requiredConfig: ['baseUrl', 'username', 'password'],
+      requiredConfig: ['baseUrl'],
 
       upload: function(context) {
         var restClient  = this.readConfig('restClient');

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -8,15 +8,23 @@ module.exports = CoreObject.extend({
     this._super.apply(this, arguments);
 
     this._options = options;
-    this._request = request.defaults({
+    var config = {
       baseUrl: options.baseUrl,
       uri: '',
-      auth: {
+      json: true
+    };
+    if (options.username && options.password) {
+      config.auth = {
         username: options.username,
         password: options.password
-      },
-      json: true
-    });
+      }
+    } else if (options.queryString) {
+      config.qs = options.queryString;
+    } else {
+      throw new Error('auth or queryString must be configured.')
+    }
+
+    this._request = request.defaults(config);
   },
 
   upload: function(keyPrefix, revisionKey, value) {


### PR DESCRIPTION
I'd like to use an `api_key=abcde` query string parameter to auth with our rails application. Instead of hard-coding `api_key`, `apiKey` or some other name I decided to make queryString a hash. 