### PR TITLE
Make keyPrefix optional

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -20,7 +20,8 @@ module.exports = CoreObject.extend({
   },
 
   upload: function(keyPrefix, revisionKey, value) {
-    var uploadKey = keyPrefix + ':' + revisionKey;
+    var uploadKey = this._uploadKey(keyPrefix, revisionKey);
+
     var requestBody = {
       id: uploadKey,
       body: value
@@ -59,7 +60,11 @@ module.exports = CoreObject.extend({
   },
 
   _listRevisions: function(keyPrefix) {
-    var qs = { prefix: keyPrefix };
+    var qs = {};
+
+    if (keyPrefix) {
+      qs.prefix = keyPrefix;
+    }
 
     return denodeify(this._request.get)({ qs: qs })
       .then(function(response) {
@@ -74,7 +79,7 @@ module.exports = CoreObject.extend({
   },
 
   _validateRevisionKey: function(keyPrefix, revisionKey, revisions) {
-    var uploadKey = keyPrefix + ':' + revisionKey;
+    var uploadKey = this._uploadKey(keyPrefix, revisionKey);
     var isPresent = revisions.some(function(revision) {
       return revision.revision === uploadKey;
     });
@@ -83,8 +88,16 @@ module.exports = CoreObject.extend({
   },
 
   _activateRevision: function(keyPrefix, revisionKey) {
-    var uploadKey = keyPrefix + ':' + revisionKey;
+    var uploadKey = this._uploadKey(keyPrefix, revisionKey);
 
     return denodeify(this._request.put)({ uri: uploadKey });
+  },
+
+  _uploadKey: function(keyPrefix, revisionKey) {
+    if (keyPrefix) {
+      return keyPrefix + ':' + revisionKey;
+    } else {
+      return revisionKey;
+    }
   }
 });


### PR DESCRIPTION
If keyPrefix is set to a falsy value, we don't use it as part of our upload key. The default keyPrefix remains the project name for backwards compatibility.

Fix #2