### PR TITLE
Support ember-cli-deploy-display-revisions v2.1.3

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -73,10 +73,16 @@ module.exports = CoreObject.extend({
 
     return denodeify(this._request.get)({ qs: qs }).then(function (response) {
       return response.body.map(function (revision) {
+        // ember-cli-deploy-display-revisions expects the timestamp to be either
+        // a JS Date object or the number of milliseconds since 1970-01-01T00:00:00
+        var revisionData = Object.assign({}, revision.revision_data, {
+          timestamp: new Date(revision.revision_data.timestamp),
+        });
+
         return {
           revision: revision.id,
-          revisionData: revision.revision_data,
-          timestamp: new Date(revision.created_at),
+          revisionData: revisionData,
+          timestamp: new Date(revision.created_at * 1000),
           active: revision.current,
         };
       });


### PR DESCRIPTION
As of https://github.com/ember-cli-deploy/ember-cli-deploy-display-revisions/pull/42, `ember-cli-deploy-display-revisions` doesn't support ISO 8601 dates for the revision timestamp. Instead, it either expects a JS `Date` object or a number representing the number of milliseconds from epoch. 

This converts the timestamp to a JS `Date` before passing it off. Additionally, it fixes the `timestamp` root key which was in seconds, not milliseconds, causing the date to be in 1970.

This will be another major version!