### PR TITLE
Update github action to use native containers and browser setup actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,10 @@ on: [push]
 
 jobs:
   test:
-    container: circleci/node:16-browsers
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ["16"]
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_BOT_URL }}
       JOBS: 1
@@ -15,9 +17,21 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v2
+      - name: setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - name: setup chrome
+        uses: browser-actions/setup-chrome@latest
+      - uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ember-cli-deploy-rest-${{ matrix.node }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ember-cli-deploy-rest-${{ matrix.node }}
       - name: npm install
         run: |
-          npm install
+          npm ci
       - name: npm lint
         run: |
           npm run lint:js

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    container: circleci/node:12-browsers
+    container: circleci/node:16-browsers
     runs-on: ubuntu-18.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_BOT_URL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,19 +14,13 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Setup file system permissions
-        run: |
-          sudo mkdir -pv $GITHUB_WORKSPACE /github /__w/_temp
-          sudo chmod 777 -R $GITHUB_WORKSPACE /github /__w/_temp
       - uses: actions/checkout@v2
       - name: npm install
         run: |
           npm install
       - name: npm lint
         run: |
-          export PATH="${GITHUB_WORKSPACE}/node_modules/.bin:$PATH"
           npm run lint:js
       - name: npm test
         run: |
-          export PATH="${GITHUB_WORKSPACE}/node_modules/.bin:$PATH"
           npm run test -- -r=dot

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,11 +30,8 @@ jobs:
           restore-keys: |
             ember-cli-deploy-rest-${{ matrix.node }}
       - name: npm install
-        run: |
-          npm ci
+        run: npm ci
       - name: npm lint
-        run: |
-          npm run lint:js
+        run: npm run lint:js
       - name: npm test
-        run: |
-          npm run test -- -r=dot
+        run: npm run test -- -r=dot


### PR DESCRIPTION
There was some issue with the circleci image, where github was encountering permissions errors when trying to checkout the repo. This stops using the circleci image, and opts for a third-party action to setup chrome. If we want firefox or safari later, the organization also has actions for those as well.