### PR TITLE
Update ember to 3.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
-    "ember-cli": "^3.28.5",
+    "ember-cli": "^3.28.6",
     "eslint": "^8.7.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ember": "^10.5.8",


### PR DESCRIPTION
Part of the [Road to Ember 4.0](https://www.notion.so/custio/Road-to-Ember-4-0-53e98286912b4f5cb6b19e18926bf0e8)

This updates `ember-cli-deploy-rest` to Ember 3.28.