### PR TITLE
Fix an issue with upstream `ember-cli-deploy-display-revisions`

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -107,12 +107,10 @@ module.exports = CoreObject.extend({
     return denodeify(this._request.get)({ qs: qs }).then(function (response) {
       var responseBody = useHydra ? response.body.filter((rev) => rev.app === 'journeys') : response.body;
 
-      console.log('responseBody:', JSON.stringify(responseBody, null, 2));
-
       return responseBody.map(function (revision) {
         // ember-cli-deploy-display-revisions expects the timestamp to be either
         // a JS Date object or the number of milliseconds since 1970-01-01T00:00:00
-        var revisionData = {};
+        var revisionData = null;
         if (revision.revision_data) {
           revisionData = Object.assign({}, revision.revision_data, {
             timestamp: new Date(revision.revision_data.timestamp),

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -13,9 +13,9 @@ module.exports = CoreObject.extend({
 
     var auth =
       options.useBearerToken === true &&
-        options.bearer !== undefined &&
-        options.bearer !== null &&
-        options.bearer.length !== 0
+      options.bearer !== undefined &&
+      options.bearer !== null &&
+      options.bearer.length !== 0
         ? { bearer: options.bearer }
         : { username: options.username, password: options.password };
 
@@ -105,9 +105,9 @@ module.exports = CoreObject.extend({
     }
 
     return denodeify(this._request.get)({ qs: qs }).then(function (response) {
-      var responseBody = useHydra
-        ? response.body.filter(rev => rev.app === "journeys")
-        : response.body;
+      var responseBody = useHydra ? response.body.filter((rev) => rev.app === 'journeys') : response.body;
+
+      console.log('responseBody:', JSON.stringify(responseBody, null, 2));
 
       return responseBody.map(function (revision) {
         // ember-cli-deploy-display-revisions expects the timestamp to be either
@@ -142,7 +142,7 @@ module.exports = CoreObject.extend({
     var uri = this._uploadKey(keyPrefix, revisionKey);
 
     if (useHydra) {
-      uri = `journeys/${uri}/activate`
+      uri = `journeys/${uri}/activate`;
     }
 
     return denodeify(this._request.put)({ uri });


### PR DESCRIPTION
With the move to hydra, it looks like we're no longer storing `revision_data` in the db (response snippet below). The problem is that with our implementation, if `revisionData` is not falsy, `ember-cli-deploy-display-revisions` will [try to use a structure-specific table](https://github.com/ember-cli-deploy/ember-cli-deploy-display-revisions/blob/9287405c68ba6c0608de4f429a5e1aab8a0764b8/index.js#L34) rather than a more generic one to display the revisions.

<details>
<summary>Sample back end response</summary>

```
responseBody: [
  {
    "id": "20.0.21+8883ce7e",
    "app": "journeys",
    "created_at": 1691018525,
    "updated_at": 1691018525
  },
  {
    "id": "20.0.20+6cb143f4",
    "app": "journeys",
    "created_at": 1691016947,
    "updated_at": 1691016947
  },
  {
    "id": "20.0.19+6608f732",
    "app": "journeys",
    "created_at": 1691008333,
    "updated_at": 1691008333
  },
  {
    "id": "20.0.18+9cc1b465",
    "app": "journeys",
    "created_at": 1690993978,
    "updated_at": 1690993978
  },
  {
    "id": "20.0.17+f8e88f3c",
    "app": "journeys",
    "created_at": 1690987611,
    "updated_at": 1690987611
  },
  {
    "id": "20.0.16+77df7fdb",
    "app": "journeys",
    "created_at": 1690973749,
    "updated_at": 1690973749
  },
  {
    "id": "20.0.15+3ee45823",
    "app": "journeys",
    "created_at": 1690948808,
    "updated_at": 1690948808
  },
  {
    "id": "20.0.14+c1ec8051",
    "app": "journeys",
    "created_at": 1690939576,
    "updated_at": 1690939576
  },
  {
    "id": "20.0.13+fa54b892",
    "app": "journeys",
    "created_at": 1690881565,
    "updated_at": 1690881565
  },
  {
    "id": "20.0.12+e0064394",
    "app": "journeys",
    "created_at": 1690835543,
    "updated_at": 1690835543
  },
  {
    "id": "20.0.10+346d2bdb",
    "app": "journeys",
    "created_at": 1690833706,
    "updated_at": 1690833706
  },
  {
    "id": "20.0.10+32d4ca87",
    "app": "journeys",
    "created_at": 1690830365,
    "updated_at": 1690830365
  },
  {
    "id": "20.0.9+ec780821",
    "app": "journeys",
    "created_at": 1690826525,
    "updated_at": 1690826525
  },
  {
    "id": "20.0.8+985b6e64",
    "app": "journeys",
    "created_at": 1690813741,
    "updated_at": 1690813741
  },
  {
    "id": "v20.0.7+3b09e001",
    "app": "journeys",
    "created_at": 1690797041,
    "updated_at": 1690797041
  }
]
```
</details>

This makes the default `null` unless there is actually revision data. This should also be backwards compatible for non-hydra uses.

This also includes some secondary prettier formatting.