### PR TITLE
Update to node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["18"]
+        node: ["18", "22"]
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_BOT_URL }}
       JOBS: 1


### PR DESCRIPTION
What it says on the tin: Updates our node version to v22, the current LTS until october, when we get to do this again.