### PR TITLE
support for deploying to services/ui_api release APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,26 @@
 
 # ember-cli-deploy-rest
 
-An ember-cli-deploy plugin to upload index.html files to a REST API. This is useful if you wrap your Ember app in a traditional web app, such as Rails.
+A modified ember-cli-deploy plugin to upload index.html files to a REST API. This is useful if you wrap your Ember app in a traditional web app, such as Rails.
 
 ## API requirements
 
-Your REST API should follow the spec below. Note that the base URL is configurable; for these examples we assume it's `https://yourapp.com/ember-revisions`.
+Your REST API should follow the spec below. Note that the base URL is configurable.
+
+The original implementation assumes an example base URL of `https://yourapp.com/ember-revisions`.
 
 - Authenticate with basic auth (please use HTTPS!)
 - `GET /ember-revisions`: returns a JSON array of objects for the stored revisions. Fields are `id` (revision key), `created_at` (upload timestamp), `revision_data` (usually contains revision metadata) and `current` (boolean)
 - `POST /ember-revisions`: expects a JSON body with fields `id` (revision key) and `body` (the index.html contents)
 - `PUT /ember-revisions/<id>`: activates the revision with key `id`
+
+Our Customer.io implementation has slightly different endpoints and parameters.
+
+- Authenticate with basic auth (please use HTTPS!), utilizing the prefix `Bearer`
+- `GET /`: returns a JSON array of objects for all apps (ONLY ON HYDRA, NOT SERVICES)
+- `GET /<app_name>`: returns a JSON array of objects for the specified app
+- `POST /<app_name>`: expects a JSON body with the fields `version` (revision key) and `body` (the index.html contents)
+- `PUT /<app_name>/<version>/activate`: activates the specified app with the specified version
 
 ## Quick Start
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ module.exports = {
 
       // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
       defaultConfig: {
+        appName: 'journeys',
         useHydra: false,
+        useServices: false,
         useBearerToken: false,
         bearer: undefined,
         filePattern: 'index.html',
@@ -64,6 +66,7 @@ module.exports = {
 
       upload: function () {
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
         var restClient = this.readConfig('restClient');
         var revisionKey = this.readConfig('revisionKey');
         var distDir = this.readConfig('distDir');
@@ -78,6 +81,14 @@ module.exports = {
         if (useHydra) {
           return this._readFileContents(filePath)
             .then(restClient.uploadAppRelease.bind(restClient, keyPrefix, revisionKey, appName))
+            .then(this._uploadSuccessMessage.bind(this))
+            .then(function (key) {
+              return { key: key };
+            })
+            .catch(this._errorMessage.bind(this));
+        } else if (useServices) {
+          return this._readFileContents(filePath)
+            .then(restClient.updateServicesRelease.bind(restClient, keyPrefix, revisionKey, appName))
             .then(this._uploadSuccessMessage.bind(this))
             .then(function (key) {
               return { key: key };
@@ -98,8 +109,9 @@ module.exports = {
         var restClient = this.readConfig('restClient');
         var keyPrefix = this.readConfig('keyPrefix');
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
 
-        var revisionKey = restClient.activeRevision(keyPrefix, useHydra);
+        var revisionKey = restClient.activeRevision(keyPrefix, appName, useHydra || useServices, useHydra);
 
         return {
           revisionData: {
@@ -112,12 +124,14 @@ module.exports = {
         var restClient = this.readConfig('restClient');
         var revisionKey = this.readConfig('revisionKey');
         var keyPrefix = this.readConfig('keyPrefix');
+        var appName = this.readConfig('appName');
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
 
         this.log('Activating revision `' + revisionKey + '`', {
           verbose: true,
         });
-        return Promise.resolve(restClient.activate(keyPrefix, revisionKey, useHydra))
+        return Promise.resolve(restClient.activate(keyPrefix, appName, revisionKey, useHydra || useServices, useHydra))
           .then(this.log.bind(this, '✔ Activated revision `' + revisionKey + '`', {}))
           .then(function () {
             return {
@@ -139,12 +153,14 @@ module.exports = {
       fetchInitialRevisions: function (/* context */) {
         var restClient = this.readConfig('restClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var appName = this.readConfig('appName');
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
 
         this.log('Listing initial revisions for key: `' + keyPrefix + '`', {
           verbose: true,
         });
-        return Promise.resolve(restClient.fetchRevisions(keyPrefix, useHydra))
+        return Promise.resolve(restClient.fetchRevisions(keyPrefix, appName, useHydra || useServices, useHydra))
           .then(function (revisions) {
             return {
               initialRevisions: revisions,
@@ -156,10 +172,12 @@ module.exports = {
       fetchRevisions: function (/* context */) {
         var restClient = this.readConfig('restClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var appName = this.readConfig('appName');
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
 
         this.log('Listing revisions for key: `' + keyPrefix + '`');
-        return restClient.fetchRevisions(keyPrefix, useHydra).catch(this._errorMessage.bind(this));
+        return restClient.fetchRevisions(keyPrefix, appName, useHydra || useServices, useHydra).catch(this._errorMessage.bind(this));
       },
 
       _readFileContents: function (path) {

--- a/index.js
+++ b/index.js
@@ -78,26 +78,7 @@ module.exports = {
 
         this.log('Uploading `' + filePath + '`', { verbose: true });
 
-        if (useHydra && useServices) {
-          return this._readFileContents(filePath)
-            .then((fileContents) => {
-              return Promise.all([
-                restClient.uploadReleaseToHydra(keyPrefix, revisionKey, appName, fileContents),
-                restClient.updateReleaseToServices(keyPrefix, revisionKey, appName, fileContents),
-              ]);
-            })
-            .then(([hydraKey, servicesKey]) => {
-              // both keys _should_ be the same
-              if (hydraKey !== servicesKey) {
-                this._uploadSuccessMessage(hydraKey);
-                this._uploadSuccessMessage(servicesKey);
-              } else {
-                this._uploadSuccessMessage(servicesKey);
-              }
-              return { key: servicesKey };
-            })
-            .catch(this._errorMessage.bind(this));
-        } else if (useHydra) {
+        if (useHydra) {
           return this._readFileContents(filePath)
             .then(restClient.uploadReleaseToHydra.bind(restClient, keyPrefix, revisionKey, appName))
             .then(this._uploadSuccessMessage.bind(this))

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = {
         this.log('Activating revision `' + revisionKey + '`', {
           verbose: true,
         });
-        return Promise.resolve(restClient.activate(keyPrefix, appName, revisionKey, useHydra || useServices, useHydra))
+        return Promise.resolve(restClient.activate(keyPrefix, revisionKey, appName, useHydra || useServices, useHydra))
           .then(this.log.bind(this, '✔ Activated revision `' + revisionKey + '`', {}))
           .then(function () {
             return {

--- a/index.js
+++ b/index.js
@@ -78,7 +78,26 @@ module.exports = {
 
         this.log('Uploading `' + filePath + '`', { verbose: true });
 
-        if (useHydra) {
+        if (useHydra && useServices) {
+          return this._readFileContents(filePath)
+            .then((fileContents) => {
+              return Promise.all([
+                restClient.uploadReleaseToHydra(keyPrefix, revisionKey, appName, fileContents),
+                restClient.updateReleaseToServices(keyPrefix, revisionKey, appName, fileContents),
+              ]);
+            })
+            .then(([hydraKey, servicesKey]) => {
+              // both keys _should_ be the same
+              if (hydraKey !== servicesKey) {
+                this._uploadSuccessMessage(hydraKey);
+                this._uploadSuccessMessage(servicesKey);
+              } else {
+                this._uploadSuccessMessage(servicesKey);
+              }
+              return { key: servicesKey };
+            })
+            .catch(this._errorMessage.bind(this));
+        } else if (useHydra) {
           return this._readFileContents(filePath)
             .then(restClient.uploadReleaseToHydra.bind(restClient, keyPrefix, revisionKey, appName))
             .then(this._uploadSuccessMessage.bind(this))

--- a/index.js
+++ b/index.js
@@ -178,7 +178,8 @@ module.exports = {
         var useServices = this.readConfig('useServices');
 
         this.log('Listing revisions for key: `' + keyPrefix + '`');
-        return restClient.fetchRevisions(keyPrefix, appName, useHydra || useServices, useHydra)
+        return restClient
+          .fetchRevisions(keyPrefix, appName, useHydra || useServices, useHydra)
           .catch(this._errorMessage.bind(this));
       },
 

--- a/index.js
+++ b/index.js
@@ -178,7 +178,8 @@ module.exports = {
         var useServices = this.readConfig('useServices');
 
         this.log('Listing revisions for key: `' + keyPrefix + '`');
-        return restClient.fetchRevisions(keyPrefix, appName, useHydra || useServices, useHydra).catch(this._errorMessage.bind(this));
+        return restClient.fetchRevisions(keyPrefix, appName, useHydra || useServices, useHydra)
+          .catch(this._errorMessage.bind(this));
       },
 
       _readFileContents: function (path) {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = {
 
         if (useHydra) {
           return this._readFileContents(filePath)
-            .then(restClient.uploadAppRelease.bind(restClient, keyPrefix, revisionKey, appName))
+            .then(restClient.uploadReleaseToHydra.bind(restClient, keyPrefix, revisionKey, appName))
             .then(this._uploadSuccessMessage.bind(this))
             .then(function (key) {
               return { key: key };
@@ -88,7 +88,7 @@ module.exports = {
             .catch(this._errorMessage.bind(this));
         } else if (useServices) {
           return this._readFileContents(filePath)
-            .then(restClient.updateServicesRelease.bind(restClient, keyPrefix, revisionKey, appName))
+            .then(restClient.updateReleaseToServices.bind(restClient, keyPrefix, revisionKey, appName))
             .then(this._uploadSuccessMessage.bind(this))
             .then(function (key) {
               return { key: key };

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ module.exports = {
       willActivate: function (/* context */) {
         var restClient = this.readConfig('restClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var appName = this.readConfig('appName');
         var useHydra = this.readConfig('useHydra');
         var useServices = this.readConfig('useServices');
 

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -109,7 +109,8 @@ module.exports = CoreObject.extend({
     }
 
     return denodeify(this._request.get)({ uri, qs: qs }).then(function (response) {
-      var responseBody = useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
+      var responseBody =
+        useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
 
       if (response.statusCode == 404) {
         return [];

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -45,7 +45,7 @@ module.exports = CoreObject.extend({
     var version = this._uploadKey(keyPrefix, revisionKey);
 
     var requestBody = {
-      id: version,
+      version,
       body: value,
     };
 

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -45,7 +45,7 @@ module.exports = CoreObject.extend({
     var version = this._uploadKey(keyPrefix, revisionKey);
 
     var requestBody = {
-      version,
+      id: version,
       body: value,
     };
 

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -104,7 +104,7 @@ module.exports = CoreObject.extend({
     }
 
     var uri = '';
-    if (!isSummaryEndpoint) {
+    if (useReleaseEndpoint && !isSummaryEndpoint) {
       uri = appName;
     }
 

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -90,7 +90,7 @@ module.exports = CoreObject.extend({
       var i;
 
       for (i = 0; i < revisions.length; i++) {
-        if (revisions[i].current) {
+        if (revisions[i].active) {
           return revisions[i].version;
         }
       }
@@ -127,7 +127,7 @@ module.exports = CoreObject.extend({
         }
 
         return {
-          revision: revision.id,
+          revision: useReleaseEndpoint && !isSummaryEndpoint ? revision.version : revision.id,
           revisionData: revisionData,
           timestamp: new Date(revision.created_at * 1000),
           active: revision.current,

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -27,7 +27,7 @@ module.exports = CoreObject.extend({
     });
   },
 
-  uploadAppRelease: function (keyPrefix, revisionKey, appName, value) {
+  uploadReleaseToHydra: function (keyPrefix, revisionKey, appName, value) {
     var version = this._uploadKey(keyPrefix, revisionKey);
 
     var requestBody = {
@@ -41,7 +41,7 @@ module.exports = CoreObject.extend({
     });
   },
 
-  uploadHydraRelease: function (keyPrefix, revisionKey, value) {
+  updateReleaseToServices: function (keyPrefix, revisionKey, appName, value) {
     var version = this._uploadKey(keyPrefix, revisionKey);
 
     var requestBody = {
@@ -49,7 +49,7 @@ module.exports = CoreObject.extend({
       body: value,
     };
 
-    return denodeify(this._request.post)({ body: requestBody }).then(function () {
+    return denodeify(this._request.post)({ uri: appName, body: requestBody }).then(function () {
       return version;
     });
   },
@@ -71,22 +71,22 @@ module.exports = CoreObject.extend({
     });
   },
 
-  activate: function (keyPrefix, revisionKey, useHydra) {
-    return this._listRevisions(keyPrefix, useHydra)
+  activate: function (keyPrefix, revisionKey, appName, useReleaseEndpoint, isSummaryEndpoint) {
+    return this._listRevisions(keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint)
       .then(this._validateRevisionKey.bind(this, keyPrefix, revisionKey))
-      .then(this._activateRevision.bind(this, keyPrefix, revisionKey, useHydra));
+      .then(this._activateRevision.bind(this, keyPrefix, revisionKey, useReleaseEndpoint));
   },
 
-  fetchRevisions: function (keyPrefix, useHydra) {
-    return this._listRevisions(keyPrefix, useHydra).then(function (revisions) {
+  fetchRevisions: function (keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint) {
+    return this._listRevisions(keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint).then(function (revisions) {
       return {
         revisions: revisions,
       };
     });
   },
 
-  activeRevision: function (keyPrefix, useHydra) {
-    return this._listRevisions(keyPrefix, useHydra).then(function (revisions) {
+  activeRevision: function (keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint) {
+    return this._listRevisions(keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint).then(function (revisions) {
       var i;
 
       for (i = 0; i < revisions.length; i++) {
@@ -97,15 +97,19 @@ module.exports = CoreObject.extend({
     });
   },
 
-  _listRevisions: function (keyPrefix, useHydra) {
+  _listRevisions: function (keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint) {
     var qs = {};
-
     if (keyPrefix) {
       qs.prefix = keyPrefix;
     }
 
-    return denodeify(this._request.get)({ qs: qs }).then(function (response) {
-      var responseBody = useHydra ? response.body.filter((rev) => rev.app === 'journeys') : response.body;
+    var uri = '';
+    if (!isSummaryEndpoint) {
+      uri = appName;
+    }
+
+    return denodeify(this._request.get)({ uri, qs: qs }).then(function (response) {
+      var responseBody = useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
 
       return responseBody.map(function (revision) {
         // ember-cli-deploy-display-revisions expects the timestamp to be either
@@ -136,10 +140,10 @@ module.exports = CoreObject.extend({
     return isPresent ? Promise.resolve() : Promise.reject('`' + uploadKey + '` is not a valid revision key');
   },
 
-  _activateRevision: function (keyPrefix, revisionKey, useHydra) {
+  _activateRevision: function (keyPrefix, revisionKey, useReleaseEndpoint) {
     var uri = this._uploadKey(keyPrefix, revisionKey);
 
-    if (useHydra) {
+    if (useReleaseEndpoint) {
       uri = `journeys/${uri}/activate`;
     }
 

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -90,7 +90,7 @@ module.exports = CoreObject.extend({
       var i;
 
       for (i = 0; i < revisions.length; i++) {
-        if (revisions[i].active) {
+        if (revisions[i].current) {
           return revisions[i].version;
         }
       }
@@ -110,6 +110,10 @@ module.exports = CoreObject.extend({
 
     return denodeify(this._request.get)({ uri, qs: qs }).then(function (response) {
       var responseBody = useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
+
+      if (response.statusCode == 404) {
+        return [];
+      }
 
       return responseBody.map(function (revision) {
         // ember-cli-deploy-display-revisions expects the timestamp to be either


### PR DESCRIPTION
This PR integrates with services/ui_api release endpoints since hydra release endpoints are deprecated.

For some historical context, the previous version of this library was referenced as a specific non-main git commit (seen in https://github.com/customerio/ui/pull/11790/changes). I believe this was just neglected cleanup after a major project and will be moving forward with merging this into the main branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core deploy/activate/revision-listing request shapes and response parsing across multiple modes; misconfiguration or endpoint differences could lead to failed deploys or activating the wrong revision.
> 
> **Overview**
> Adds a new deployment mode (`useServices`) and app scoping (`appName`, default `journeys`) so uploads, activation, and revision listing can target either the legacy REST API, Hydra’s summary endpoint, or Services’ per-app release endpoints.
> 
> Refactors `lib/rest-client` to select request `uri`, map differing response fields (`id` vs `version`), and handle 404-as-empty for revision listing; updates method names/signatures accordingly and documents the Customer.io-specific endpoints in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89d67458dd751ff4488d0eee126c71bb7cea6382. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->