### PR TITLE
REF: DX-1182 Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,26 @@
 
 # ember-cli-deploy-rest
 
-An ember-cli-deploy plugin to upload index.html files to a REST API. This is useful if you wrap your Ember app in a traditional web app, such as Rails.
+A modified ember-cli-deploy plugin to upload index.html files to a REST API. This is useful if you wrap your Ember app in a traditional web app, such as Rails.
 
 ## API requirements
 
-Your REST API should follow the spec below. Note that the base URL is configurable; for these examples we assume it's `https://yourapp.com/ember-revisions`.
+Your REST API should follow the spec below. Note that the base URL is configurable.
+
+The original implementation assumes an example base URL of `https://yourapp.com/ember-revisions`.
 
 - Authenticate with basic auth (please use HTTPS!)
 - `GET /ember-revisions`: returns a JSON array of objects for the stored revisions. Fields are `id` (revision key), `created_at` (upload timestamp), `revision_data` (usually contains revision metadata) and `current` (boolean)
 - `POST /ember-revisions`: expects a JSON body with fields `id` (revision key) and `body` (the index.html contents)
 - `PUT /ember-revisions/<id>`: activates the revision with key `id`
+
+Our Customer.io implementation has slightly different endpoints and parameters.
+
+- Authenticate with basic auth (please use HTTPS!), utilizing the prefix `Bearer`
+- `GET /`: returns a JSON array of objects for all apps (ONLY ON HYDRA, NOT SERVICES)
+- `GET /<app_name>`: returns a JSON array of objects for the specified app
+- `POST /<app_name>`: expects a JSON body with the fields `version` (revision key) and `body` (the index.html contents)
+- `PUT /<app_name>/<version>/activate`: activates the specified app with the specified version
 
 ## Quick Start
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ module.exports = {
 
       // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
       defaultConfig: {
+        appName: 'journeys',
         useHydra: false,
+        useServices: false,
         useBearerToken: false,
         bearer: undefined,
         filePattern: 'index.html',
@@ -64,6 +66,7 @@ module.exports = {
 
       upload: function () {
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
         var restClient = this.readConfig('restClient');
         var revisionKey = this.readConfig('revisionKey');
         var distDir = this.readConfig('distDir');
@@ -77,7 +80,15 @@ module.exports = {
 
         if (useHydra) {
           return this._readFileContents(filePath)
-            .then(restClient.uploadAppRelease.bind(restClient, keyPrefix, revisionKey, appName))
+            .then(restClient.uploadReleaseToHydra.bind(restClient, keyPrefix, revisionKey, appName))
+            .then(this._uploadSuccessMessage.bind(this))
+            .then(function (key) {
+              return { key: key };
+            })
+            .catch(this._errorMessage.bind(this));
+        } else if (useServices) {
+          return this._readFileContents(filePath)
+            .then(restClient.updateReleaseToServices.bind(restClient, keyPrefix, revisionKey, appName))
             .then(this._uploadSuccessMessage.bind(this))
             .then(function (key) {
               return { key: key };
@@ -97,9 +108,11 @@ module.exports = {
       willActivate: function (/* context */) {
         var restClient = this.readConfig('restClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var appName = this.readConfig('appName');
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
 
-        var revisionKey = restClient.activeRevision(keyPrefix, useHydra);
+        var revisionKey = restClient.activeRevision(keyPrefix, appName, useHydra || useServices, useHydra);
 
         return {
           revisionData: {
@@ -112,12 +125,14 @@ module.exports = {
         var restClient = this.readConfig('restClient');
         var revisionKey = this.readConfig('revisionKey');
         var keyPrefix = this.readConfig('keyPrefix');
+        var appName = this.readConfig('appName');
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
 
         this.log('Activating revision `' + revisionKey + '`', {
           verbose: true,
         });
-        return Promise.resolve(restClient.activate(keyPrefix, revisionKey, useHydra))
+        return Promise.resolve(restClient.activate(keyPrefix, revisionKey, appName, useHydra || useServices, useHydra))
           .then(this.log.bind(this, '✔ Activated revision `' + revisionKey + '`', {}))
           .then(function () {
             return {
@@ -139,12 +154,14 @@ module.exports = {
       fetchInitialRevisions: function (/* context */) {
         var restClient = this.readConfig('restClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var appName = this.readConfig('appName');
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
 
         this.log('Listing initial revisions for key: `' + keyPrefix + '`', {
           verbose: true,
         });
-        return Promise.resolve(restClient.fetchRevisions(keyPrefix, useHydra))
+        return Promise.resolve(restClient.fetchRevisions(keyPrefix, appName, useHydra || useServices, useHydra))
           .then(function (revisions) {
             return {
               initialRevisions: revisions,
@@ -156,10 +173,14 @@ module.exports = {
       fetchRevisions: function (/* context */) {
         var restClient = this.readConfig('restClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var appName = this.readConfig('appName');
         var useHydra = this.readConfig('useHydra');
+        var useServices = this.readConfig('useServices');
 
         this.log('Listing revisions for key: `' + keyPrefix + '`');
-        return restClient.fetchRevisions(keyPrefix, useHydra).catch(this._errorMessage.bind(this));
+        return restClient
+          .fetchRevisions(keyPrefix, appName, useHydra || useServices, useHydra)
+          .catch(this._errorMessage.bind(this));
       },
 
       _readFileContents: function (path) {

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -10,14 +10,47 @@ module.exports = CoreObject.extend({
     this._super.apply(this, arguments);
 
     this._options = options;
+
+    var auth =
+      options.useBearerToken === true &&
+        options.bearer !== undefined &&
+        options.bearer !== null &&
+        options.bearer.length !== 0
+        ? { bearer: options.bearer }
+        : { username: options.username, password: options.password };
+
     this._request = request.defaults({
       baseUrl: options.baseUrl,
       uri: '',
-      auth: {
-        username: options.username,
-        password: options.password,
-      },
+      auth: auth,
       json: true,
+    });
+  },
+
+  uploadAppRelease: function (keyPrefix, revisionKey, appName, value) {
+    var version = this._uploadKey(keyPrefix, revisionKey);
+
+    var requestBody = {
+      id: version,
+      body: value,
+      app: appName,
+    };
+
+    return denodeify(this._request.post)({ body: requestBody }).then(function () {
+      return version;
+    });
+  },
+
+  uploadHydraRelease: function (keyPrefix, revisionKey, value) {
+    var version = this._uploadKey(keyPrefix, revisionKey);
+
+    var requestBody = {
+      id: version,
+      body: value,
+    };
+
+    return denodeify(this._request.post)({ body: requestBody }).then(function () {
+      return version;
     });
   },
 
@@ -38,22 +71,22 @@ module.exports = CoreObject.extend({
     });
   },
 
-  activate: function (keyPrefix, revisionKey) {
-    return this._listRevisions(keyPrefix)
+  activate: function (keyPrefix, revisionKey, useHydra) {
+    return this._listRevisions(keyPrefix, useHydra)
       .then(this._validateRevisionKey.bind(this, keyPrefix, revisionKey))
-      .then(this._activateRevision.bind(this, keyPrefix, revisionKey));
+      .then(this._activateRevision.bind(this, keyPrefix, revisionKey, useHydra));
   },
 
-  fetchRevisions: function (keyPrefix) {
-    return this._listRevisions(keyPrefix).then(function (revisions) {
+  fetchRevisions: function (keyPrefix, useHydra) {
+    return this._listRevisions(keyPrefix, useHydra).then(function (revisions) {
       return {
         revisions: revisions,
       };
     });
   },
 
-  activeRevision: function (keyPrefix) {
-    return this._listRevisions(keyPrefix).then(function (revisions) {
+  activeRevision: function (keyPrefix, useHydra) {
+    return this._listRevisions(keyPrefix, useHydra).then(function (revisions) {
       var i;
 
       for (i = 0; i < revisions.length; i++) {
@@ -64,7 +97,7 @@ module.exports = CoreObject.extend({
     });
   },
 
-  _listRevisions: function (keyPrefix) {
+  _listRevisions: function (keyPrefix, useHydra) {
     var qs = {};
 
     if (keyPrefix) {
@@ -72,12 +105,19 @@ module.exports = CoreObject.extend({
     }
 
     return denodeify(this._request.get)({ qs: qs }).then(function (response) {
-      return response.body.map(function (revision) {
+      var responseBody = useHydra
+        ? response.body.filter(rev => rev.app === "journeys")
+        : response.body;
+
+      return responseBody.map(function (revision) {
         // ember-cli-deploy-display-revisions expects the timestamp to be either
         // a JS Date object or the number of milliseconds since 1970-01-01T00:00:00
-        var revisionData = Object.assign({}, revision.revision_data, {
-          timestamp: new Date(revision.revision_data.timestamp),
-        });
+        var revisionData = {};
+        if (revision.revision_data) {
+          revisionData = Object.assign({}, revision.revision_data, {
+            timestamp: new Date(revision.revision_data.timestamp),
+          });
+        }
 
         return {
           revision: revision.id,
@@ -98,10 +138,14 @@ module.exports = CoreObject.extend({
     return isPresent ? Promise.resolve() : Promise.reject('`' + uploadKey + '` is not a valid revision key');
   },
 
-  _activateRevision: function (keyPrefix, revisionKey) {
-    var uploadKey = this._uploadKey(keyPrefix, revisionKey);
+  _activateRevision: function (keyPrefix, revisionKey, useHydra) {
+    var uri = this._uploadKey(keyPrefix, revisionKey);
 
-    return denodeify(this._request.put)({ uri: uploadKey });
+    if (useHydra) {
+      uri = `journeys/${uri}/activate`
+    }
+
+    return denodeify(this._request.put)({ uri });
   },
 
   _uploadKey: function (keyPrefix, revisionKey) {

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -13,9 +13,9 @@ module.exports = CoreObject.extend({
 
     var auth =
       options.useBearerToken === true &&
-        options.bearer !== undefined &&
-        options.bearer !== null &&
-        options.bearer.length !== 0
+      options.bearer !== undefined &&
+      options.bearer !== null &&
+      options.bearer.length !== 0
         ? { bearer: options.bearer }
         : { username: options.username, password: options.password };
 
@@ -105,14 +105,12 @@ module.exports = CoreObject.extend({
     }
 
     return denodeify(this._request.get)({ qs: qs }).then(function (response) {
-      var responseBody = useHydra
-        ? response.body.filter(rev => rev.app === "journeys")
-        : response.body;
+      var responseBody = useHydra ? response.body.filter((rev) => rev.app === 'journeys') : response.body;
 
       return responseBody.map(function (revision) {
         // ember-cli-deploy-display-revisions expects the timestamp to be either
         // a JS Date object or the number of milliseconds since 1970-01-01T00:00:00
-        var revisionData = {};
+        var revisionData = null;
         if (revision.revision_data) {
           revisionData = Object.assign({}, revision.revision_data, {
             timestamp: new Date(revision.revision_data.timestamp),
@@ -142,7 +140,7 @@ module.exports = CoreObject.extend({
     var uri = this._uploadKey(keyPrefix, revisionKey);
 
     if (useHydra) {
-      uri = `journeys/${uri}/activate`
+      uri = `journeys/${uri}/activate`;
     }
 
     return denodeify(this._request.put)({ uri });

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -109,11 +109,39 @@ module.exports = CoreObject.extend({
     }
 
     return denodeify(this._request.get)({ uri, qs: qs }).then(function (response) {
+      // Handle 404 as empty revision list
+      if (response.statusCode == 404) {
+        return [];
+      }
+
+      // Handle non-2xx status codes
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        var errorMessage = 'Failed to fetch revisions (HTTP ' + response.statusCode + ')';
+
+        // Try to extract error details from response body
+        if (response.body && response.body.errors && Array.isArray(response.body.errors)) {
+          var errorDetails = response.body.errors
+            .map(function (err) {
+              return err.detail || err.message || JSON.stringify(err);
+            })
+            .join(', ');
+          errorMessage += ': ' + errorDetails;
+        } else if (response.body && typeof response.body === 'object') {
+          errorMessage += ': ' + JSON.stringify(response.body);
+        }
+
+        return Promise.reject(new Error(errorMessage));
+      }
+
       var responseBody =
         useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
 
-      if (response.statusCode == 404) {
-        return [];
+      // Validate that responseBody is an array
+      if (!Array.isArray(responseBody)) {
+        var bodyType = responseBody === null ? 'null' : typeof responseBody;
+        return Promise.reject(
+          new Error('Expected array of revisions, but got ' + bodyType + ': ' + JSON.stringify(responseBody)),
+        );
       }
 
       return responseBody.map(function (revision) {

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -27,7 +27,7 @@ module.exports = CoreObject.extend({
     });
   },
 
-  uploadAppRelease: function (keyPrefix, revisionKey, appName, value) {
+  uploadReleaseToHydra: function (keyPrefix, revisionKey, appName, value) {
     var version = this._uploadKey(keyPrefix, revisionKey);
 
     var requestBody = {
@@ -41,7 +41,7 @@ module.exports = CoreObject.extend({
     });
   },
 
-  uploadHydraRelease: function (keyPrefix, revisionKey, value) {
+  updateReleaseToServices: function (keyPrefix, revisionKey, appName, value) {
     var version = this._uploadKey(keyPrefix, revisionKey);
 
     var requestBody = {
@@ -49,7 +49,7 @@ module.exports = CoreObject.extend({
       body: value,
     };
 
-    return denodeify(this._request.post)({ body: requestBody }).then(function () {
+    return denodeify(this._request.post)({ uri: appName, body: requestBody }).then(function () {
       return version;
     });
   },
@@ -71,22 +71,22 @@ module.exports = CoreObject.extend({
     });
   },
 
-  activate: function (keyPrefix, revisionKey, useHydra) {
-    return this._listRevisions(keyPrefix, useHydra)
+  activate: function (keyPrefix, revisionKey, appName, useReleaseEndpoint, isSummaryEndpoint) {
+    return this._listRevisions(keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint)
       .then(this._validateRevisionKey.bind(this, keyPrefix, revisionKey))
-      .then(this._activateRevision.bind(this, keyPrefix, revisionKey, useHydra));
+      .then(this._activateRevision.bind(this, keyPrefix, revisionKey, useReleaseEndpoint));
   },
 
-  fetchRevisions: function (keyPrefix, useHydra) {
-    return this._listRevisions(keyPrefix, useHydra).then(function (revisions) {
+  fetchRevisions: function (keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint) {
+    return this._listRevisions(keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint).then(function (revisions) {
       return {
         revisions: revisions,
       };
     });
   },
 
-  activeRevision: function (keyPrefix, useHydra) {
-    return this._listRevisions(keyPrefix, useHydra).then(function (revisions) {
+  activeRevision: function (keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint) {
+    return this._listRevisions(keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint).then(function (revisions) {
       var i;
 
       for (i = 0; i < revisions.length; i++) {
@@ -97,15 +97,24 @@ module.exports = CoreObject.extend({
     });
   },
 
-  _listRevisions: function (keyPrefix, useHydra) {
+  _listRevisions: function (keyPrefix, appName, useReleaseEndpoint, isSummaryEndpoint) {
     var qs = {};
-
     if (keyPrefix) {
       qs.prefix = keyPrefix;
     }
 
-    return denodeify(this._request.get)({ qs: qs }).then(function (response) {
-      var responseBody = useHydra ? response.body.filter((rev) => rev.app === 'journeys') : response.body;
+    var uri = '';
+    if (useReleaseEndpoint && !isSummaryEndpoint) {
+      uri = appName;
+    }
+
+    return denodeify(this._request.get)({ uri, qs: qs }).then(function (response) {
+      var responseBody =
+        useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
+
+      if (response.statusCode == 404) {
+        return [];
+      }
 
       return responseBody.map(function (revision) {
         // ember-cli-deploy-display-revisions expects the timestamp to be either
@@ -118,7 +127,7 @@ module.exports = CoreObject.extend({
         }
 
         return {
-          revision: revision.id,
+          revision: useReleaseEndpoint && !isSummaryEndpoint ? revision.version : revision.id,
           revisionData: revisionData,
           timestamp: new Date(revision.created_at * 1000),
           active: revision.current,
@@ -136,10 +145,10 @@ module.exports = CoreObject.extend({
     return isPresent ? Promise.resolve() : Promise.reject('`' + uploadKey + '` is not a valid revision key');
   },
 
-  _activateRevision: function (keyPrefix, revisionKey, useHydra) {
+  _activateRevision: function (keyPrefix, revisionKey, useReleaseEndpoint) {
     var uri = this._uploadKey(keyPrefix, revisionKey);
 
-    if (useHydra) {
+    if (useReleaseEndpoint) {
       uri = `journeys/${uri}/activate`;
     }
 


### PR DESCRIPTION
REF: [DX-1182](https://linear.app/customerio/issue/DX-1182/investigate-failing-customerioui-github-actions-job)

## 🆕 Changes

This PR improves error handling in the `_listRevisions` function of the REST client to prevent cryptic TypeErrors when API requests fail.

### Problem

During deployment workflows, when the releases API returned error responses (401 Unauthorized, 500 Internal Server Error, network errors, etc.), the plugin would crash with an unhelpful error message:

```
TypeError: responseBody.map is not a function
```

This occurred because the code:
1. Only handled 404 status codes
2. Did not validate HTTP status codes before processing responses
3. Did not verify `responseBody` was an array before calling `.map()`

When the API returned an error object like `{"errors":[{"detail":"unauthorized","status":"401"}]}`, attempting to call `.map()` on it caused the TypeError, obscuring the actual problem.

### Solution

Enhanced error handling to:
- ✅ Validate HTTP status codes and reject non-2xx responses with descriptive errors
- ✅ Extract and display actual error messages from API error responses
- ✅ Validate that `responseBody` is an array before calling `.map()`
- ✅ Provide clear, actionable error messages for debugging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment upload/activate and revision-listing flows to support alternate endpoints and Bearer auth, which could affect production deploy behavior if misconfigured. Error-handling improvements reduce failures but introduce new branching and response-shape assumptions.
> 
> **Overview**
> Adds optional Customer.io-specific deployment modes (via new `defaultConfig` flags like `useHydra`, `useServices`, `appName`, and Bearer-token auth) that switch `upload`, `activate`, and revision-listing calls to new REST endpoints.
> 
> Improves `RestClient._listRevisions` robustness by handling non-2xx HTTP responses with descriptive errors, treating `404` as an empty list, and validating the response body is an array before mapping, avoiding cryptic runtime `TypeError`s.
> 
> Updates activation/listing logic to pass app/endpoint mode through, adjust revision id selection (`id` vs `version`), and document the alternate API contract in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7072468ecd68bea3cf577ba3624954448c78f3af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->