### PR TITLE
REF: DX-1182 Prevent TypeError when API returns error responses

### DIFF
--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -133,16 +133,15 @@ module.exports = CoreObject.extend({
         return Promise.reject(new Error(errorMessage));
       }
 
-      var responseBody =
-        useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
-
-      // Validate that responseBody is an array
-      if (!Array.isArray(responseBody)) {
-        var bodyType = responseBody === null ? 'null' : typeof responseBody;
+      if (!Array.isArray(response.body)) {
+        var bodyType = response.body === null ? 'null' : typeof response.body;
         return Promise.reject(
-          new Error('Expected array of revisions, but got ' + bodyType + ': ' + JSON.stringify(responseBody)),
+          new Error('Expected array of revisions, but got ' + bodyType + ': ' + JSON.stringify(response.body)),
         );
       }
+
+      var responseBody =
+        useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
 
       return responseBody.map(function (revision) {
         // ember-cli-deploy-display-revisions expects the timestamp to be either

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -109,11 +109,39 @@ module.exports = CoreObject.extend({
     }
 
     return denodeify(this._request.get)({ uri, qs: qs }).then(function (response) {
+      // Handle 404 as empty revision list
+      if (response.statusCode == 404) {
+        return [];
+      }
+
+      // Handle non-2xx status codes
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        var errorMessage = 'Failed to fetch revisions (HTTP ' + response.statusCode + ')';
+
+        // Try to extract error details from response body
+        if (response.body && response.body.errors && Array.isArray(response.body.errors)) {
+          var errorDetails = response.body.errors
+            .map(function (err) {
+              return err.detail || err.message || JSON.stringify(err);
+            })
+            .join(', ');
+          errorMessage += ': ' + errorDetails;
+        } else if (response.body && typeof response.body === 'object') {
+          errorMessage += ': ' + JSON.stringify(response.body);
+        }
+
+        return Promise.reject(new Error(errorMessage));
+      }
+
       var responseBody =
         useReleaseEndpoint && isSummaryEndpoint ? response.body.filter((rev) => rev.app === appName) : response.body;
 
-      if (response.statusCode == 404) {
-        return [];
+      // Validate that responseBody is an array
+      if (!Array.isArray(responseBody)) {
+        var bodyType = responseBody === null ? 'null' : typeof responseBody;
+        return Promise.reject(
+          new Error('Expected array of revisions, but got ' + bodyType + ': ' + JSON.stringify(responseBody)),
+        );
       }
 
       return responseBody.map(function (revision) {


### PR DESCRIPTION
REF: [DX-1182](https://linear.app/customerio/issue/DX-1182/investigate-failing-customerioui-github-actions-job)

## 🆕 Changes

This PR improves error handling in the `_listRevisions` function of the REST client to prevent cryptic TypeErrors when API requests fail.

### Problem

During deployment workflows, when the releases API returned error responses (401 Unauthorized, 500 Internal Server Error, network errors, etc.), the plugin would crash with an unhelpful error message:

```
TypeError: responseBody.map is not a function
```

This occurred because the code:
1. Only handled 404 status codes
2. Did not validate HTTP status codes before processing responses
3. Did not verify `responseBody` was an array before calling `.map()`

When the API returned an error object like `{"errors":[{"detail":"unauthorized","status":"401"}]}`, attempting to call `.map()` on it caused the TypeError, obscuring the actual problem.

### Solution

Enhanced error handling to:
- ✅ Validate HTTP status codes and reject non-2xx responses with descriptive errors
- ✅ Extract and display actual error messages from API error responses
- ✅ Validate that `responseBody` is an array before calling `.map()`
- ✅ Provide clear, actionable error messages for debugging


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `_listRevisions` response validation and error messaging, but could alter downstream behavior by rejecting on non-2xx responses instead of attempting to process them.
> 
> **Overview**
> Improves `_listRevisions` in `lib/rest-client.js` to avoid `TypeError` crashes when the releases API returns error responses.
> 
> The client now treats 404s as an empty revision list, rejects any non-2xx HTTP response with a descriptive error (including details extracted from `body.errors`), and validates that the response body is an array before calling `.map()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f3cac5a2a854f7614c194582f14e5b701698b06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->